### PR TITLE
The logic of the Jsoniter extension has been changed

### DIFF
--- a/JsonIteratorExtra.java
+++ b/JsonIteratorExtra.java
@@ -2,11 +2,10 @@ import com.jsoniter.JsonIterator;
 import com.jsoniter.output.JsonStream;
 import com.jsoniter.spi.Decoder;
 import com.jsoniter.spi.Encoder;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.sql.Timestamp;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.UUID;
 
 import static com.jsoniter.spi.JsoniterSpi.registerTypeDecoder;
@@ -14,46 +13,41 @@ import static com.jsoniter.spi.JsoniterSpi.registerTypeEncoder;
 
 public class JsonIteratorExtra {
     public static class UUIDSupport implements Encoder, Decoder {
-        public static void registerModule () {
-            registerTypeDecoder(UUID.class, jsonIterator -> UUID.fromString(jsonIterator.readString( )));
-            registerTypeEncoder(UUID.class, (obj, stream) -> stream.writeVal(obj.toString( )));
+        @Override
+        public UUID decode (@NotNull JsonIterator jsonIterator) throws IOException {
+            String value = jsonIterator.readString( );
+            if (value.charAt(0) == '"' && value.charAt(value.length( ) - 1) == '"') {
+                return UUID.fromString(value.substring(1, value.length( ) - 1));
+            } else throw new IOException( );
         }
 
         @Override
-        public Object decode (JsonIterator jsonIterator) throws IOException {
-            return UUID.fromString(jsonIterator.readString( ));
+        public void encode (@NotNull Object obj, @NotNull JsonStream stream) throws IOException {
+            stream.writeVal(STR."\"\{obj.toString( )}\"");
         }
 
-        @Override
-        public void encode (Object obj, JsonStream stream) throws IOException {
-            stream.writeVal(obj.toString( ));
+        public static void registerHandler () {
+            UUIDSupport operator = new UUIDSupport( );
+            registerTypeDecoder(UUID.class, operator);
+            registerTypeEncoder(UUID.class, operator);
         }
     }
 
-    public record SQLTimestampSupport(SimpleDateFormat dateFormat) implements Decoder, Encoder {
+    public static class SQLTimestampSupport implements Encoder, Decoder {
         @Override
-        public Object decode (JsonIterator jsonIterator) throws IOException {
-            String timestampStr = jsonIterator.readString( );
-            return Timestamp.valueOf(timestampStr);
+        public Timestamp decode (@NotNull JsonIterator jsonIterator) throws IOException {
+            return Timestamp.valueOf(jsonIterator.readString( ));
         }
 
         @Override
-        public void encode (Object obj, JsonStream stream) throws IOException {
-            Timestamp timestamp = (Timestamp) obj;
-            stream.writeVal(timestamp.toString( ));
+        public void encode (Object obj, @NotNull JsonStream stream) throws IOException {
+            stream.writeVal(STR."\{((Timestamp) obj).getTime( )}.\{((Timestamp) obj).getNanos( )}");
         }
 
-        private Timestamp parse (JsonIterator jsonIterator) throws IOException {
-            try {
-                return new Timestamp(dateFormat.parse(jsonIterator.readString( )).getTime( ));
-            } catch (ParseException e) {
-                throw new IOException(e);
-            }
-        }
-
-        public void registerModule () {
-            registerTypeDecoder(Timestamp.class, this::parse);
-            registerTypeEncoder(Timestamp.class, (obj, stream) -> stream.writeVal(obj.toString( )));
+        public static void registerHandler () {
+            SQLTimestampSupport operator = new SQLTimestampSupport( );
+            registerTypeDecoder(Timestamp.class, operator);
+            registerTypeEncoder(Timestamp.class, operator);
         }
     }
 }

--- a/Starter.java
+++ b/Starter.java
@@ -19,8 +19,8 @@ public class Starter {
     static Authorizer authorizer;
 
     static {
-        JsonIteratorExtra.UUIDSupport.registerModule( );
-        new JsonIteratorExtra.SQLTimestampSupport(Helper.Constants.timestamp).registerModule( );
+        JsonIteratorExtra.SQLTimestampSupport.registerHandler( );
+        JsonIteratorExtra.UUIDSupport.registerHandler( );
     }
 
     static {


### PR DESCRIPTION
SQL-Timestamp is now serialized as a number with a dot after position 9 from the end
All the logic of registering the UUID and Timestamp handlers has been moved to the corresponding encoder's/decoder's classes
Fixed problems with typing the return type in decoding handlers